### PR TITLE
only supply full Api URL on the server

### DIFF
--- a/src/helpers/Api.js
+++ b/src/helpers/Api.js
@@ -19,7 +19,12 @@ export function request(url, options) {
 }
 
 export function apiFetch(path, options) {
-  return fetch(`${process.env.APP_HOST}:${process.env.APP_PORT}/api${path}&api_key=${process.env.API_KEY}`, options)
+  let apiUrl = `/api${path}&api_key=${process.env.API_KEY}`
+  if (process.env.SERVER) {
+    apiUrl = `${process.env.APP_HOST}:${process.env.APP_PORT}/api${path}&api_key=${process.env.API_KEY}`
+  }
+
+  return fetch(apiUrl, options)
     .then(checkStatus)
     .then(parseJSON)
 }

--- a/src/helpers/Api.js
+++ b/src/helpers/Api.js
@@ -19,10 +19,9 @@ export function request(url, options) {
 }
 
 export function apiFetch(path, options) {
-  let apiUrl = `/api${path}&api_key=${process.env.API_KEY}`
-  if (process.env.SERVER) {
-    apiUrl = `${process.env.APP_HOST}:${process.env.APP_PORT}/api${path}&api_key=${process.env.API_KEY}`
-  }
+  const host = `${process.env.APP_HOST}:${process.env.APP_PORT}`
+  const contextHost = (process.env.SERVER && host) || ''
+  const apiUrl = `${contextHost}/api${path}&api_key=${process.env.API_KEY}`
 
   return fetch(apiUrl, options)
     .then(checkStatus)


### PR DESCRIPTION
Solves the issue where the client tries to fetch from for example `localhost:3000` when its actually deployed to `www.some-url.com` and fails.