### PR TITLE
Hot reloading broke after removing NODE_ENV 

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -22,7 +22,7 @@ const renderApp = TheApp =>
     document.getElementById('root')
   )
 
-if (process.env.NODE_ENV === 'development' && module.hot) {
+if (module.hot) {
   module.hot.accept('./containers/App/App.js', () => {
     const theApp = require('./containers/App/App').default
     renderApp(theApp)

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -15,7 +15,7 @@ export default function configureStore(wrapEpic = (f => f), data) {
     store = createStore(app, middleware)
   }
 
-  if (process.env.NODE_ENV === 'development' && module.hot) {
+  if (module.hot) {
     module.hot.accept(
       './reducers',
       () => {


### PR DESCRIPTION
`module.hot` will only ever be defined in the `dev` context so regardless this check is pointless.